### PR TITLE
Update conan(-file)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ concurrency:
 
 env:
   # Last known good conan version
-  # 2.0.3 has a bug on Windows (conan-io/conan#13606)
-  CONAN_VERSION: 2.0.2
+  # 2.0.3 had a bug on Windows (conan-io/conan#13606)
+  CONAN_VERSION: 2.0.6
 
 jobs:
   build:
@@ -82,7 +82,7 @@ jobs:
               -c tools.cmake.cmaketoolchain:generator="NMake Makefiles" `
               -b missing `
               --output-folder=. `
-              -o with_openssl3="$Env:C2_USE_OPENSSL3"
+              -o with_openssl3=True
         shell: powershell
 
       - name: Build (Windows)

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,8 +48,8 @@ BOOST_DISABLED_OPTIONS = [
 ]
 
 
-class Chatterino(ConanFile):
-    name = "Chatterino"
+class BeastWebsocketClient(ConanFile):
+    name = "BeastWebsocketClient"
     requires = "boost/1.81.0"
     settings = "os", "compiler", "build_type", "arch"
     default_options = {

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,27 +2,73 @@ from conan import ConanFile
 from conan.tools.files import copy
 from os import path
 
+BOOST_ALL_OPTIONS = [
+    "atomic",
+    "chrono",
+    "container",
+    "context",
+    "contract",
+    "coroutine",
+    "date_time",
+    "exception",
+    "fiber",
+    "filesystem",
+    "graph",
+    "graph_parallel",
+    "iostreams",
+    "json",
+    "locale",
+    "log",
+    "math",
+    "mpi",
+    "nowide",
+    "program_options",
+    "python",
+    "random",
+    "regex",
+    "serialization",
+    "stacktrace",
+    "system",
+    "test",
+    "thread",
+    "timer",
+    "type_erasure",
+    "url",
+    "wave",
+]
+
+BOOST_ENABLED_OPTIONS = {
+    "container",
+    "json",
+    "system",
+}
+
+BOOST_DISABLED_OPTIONS = [
+    opt for opt in BOOST_ALL_OPTIONS if opt not in BOOST_ENABLED_OPTIONS
+]
+
 
 class Chatterino(ConanFile):
     name = "Chatterino"
     requires = "boost/1.81.0"
     settings = "os", "compiler", "build_type", "arch"
     default_options = {
-        "with_benchmark": False,
         "with_openssl3": False,
         "openssl*:shared": True,
     }
+    default_options.update(
+        {f"boost*:without_{opt}": True for opt in BOOST_DISABLED_OPTIONS}
+    )
+
     options = {
-        "with_benchmark": [True, False],
         # Qt is built with OpenSSL 3 from version 6.5.0 onwards
         "with_openssl3": [True, False],
     }
     generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
-        if self.options.get_safe("with_benchmark", False):
-            self.requires("benchmark/1.7.1")
-
+        self.output.warning(BOOST_DISABLED_OPTIONS)
+        self.output.warning(self.default_options)
         if self.options.get_safe("with_openssl3", False):
             self.requires("openssl/3.1.0")
         else:
@@ -41,7 +87,6 @@ class Chatterino(ConanFile):
             copy_bin(dep, "*.dylib", "bin")
             # Windows
             copy_bin(dep, "*.dll", "bin")
-            copy_bin(dep, "*.dll", "Chatterino2")  # used in CI
             # Linux
             copy(
                 self,


### PR DESCRIPTION
* Removes optional benchmark dependency
* Disables unused boost libraries
* Updates the used conan version in CI to 2.0.6
* Always uses openssl 3 in CI

---

As for the python scripts in `ast`:

They (almost) work on Windows. I needed to install `clang` 16 from pip, since that's the version I have installed (could this be a config option?) and I had to change the library file path to `<llvm-dir>/bin/libclang.dll` (this could be an environment variable, and I believe there's an environment variable like `LIBCLANG_PATH`, `LLVM_{DIR,ROOT}` that should be picked up, but I can't remember which one it is).

The `replace-in-file.sh` script should be a python script, since python is used already.