### PR TITLE
fix: improve use on Windows

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -43,6 +43,10 @@ jobs:
           echo "LIBCLANG_LIBRARY_PATH=${{ runner.temp }}/llvm/bin" >> "$GITHUB_ENV"
         shell: bash
 
+      - name: Enable Developer Command Prompt for Windows
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1.12.1
+
       - name: Cache Clang
         id: cache-llvm
         uses: actions/cache@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -43,10 +43,6 @@ jobs:
           echo "LIBCLANG_LIBRARY_PATH=${{ runner.temp }}/llvm/bin" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Enable Developer Command Prompt for Windows
-        if: startsWith(matrix.os, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1.12.1
-
       - name: Cache Clang
         id: cache-llvm
         uses: actions/cache@v3

--- a/ast/generate-and-replace-dir.py
+++ b/ast/generate-and-replace-dir.py
@@ -32,7 +32,7 @@ def main():
 
         header_path = path.path
         source_path = re.sub(r"\.hpp$", ".cpp", header_path)
-        source_path = source_path.replace("include/eventsub/", "src/")
+        source_path = re.sub(r"include[/\\]eventsub[/\\]", "src/", source_path)
 
         if not os.path.isfile(source_path):
             log.warning(f"Header file {header_path} did not have a matching source file at {source_path}")

--- a/ast/lib/build.py
+++ b/ast/lib/build.py
@@ -5,7 +5,7 @@ import os
 
 import clang.cindex
 
-from .helpers import get_clang_builtin_include_dirs
+from .helpers import get_clang_builtin_include_dirs, get_cmake_include_dirs
 from .struct import Struct
 from .walker import Walker
 
@@ -34,12 +34,17 @@ def build_structs(filename: str, build_commands: Optional[str] = None) -> List[S
     for include_dir in extra_includes:
         parse_args.append(f"-I{include_dir}")
 
-    # Append dir of file
-    file_dir = os.path.dirname(os.path.realpath(filename))
-    parse_args.append(f"-I{file_dir}")
-    # Append project include dir
-    file_subdir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(filename)), "../.."))
-    parse_args.append(f"-I{file_subdir}")
+    for dir in get_cmake_include_dirs():
+        parse_args.append("-I")
+        parse_args.append(dir)
+    else:
+        # Append default dirs
+        # - Append dir of file
+        file_dir = os.path.dirname(os.path.realpath(filename))
+        parse_args.append(f"-I{file_dir}")
+        # - Append project include dir
+        file_subdir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(filename)), "../.."))
+        parse_args.append(f"-I{file_subdir}")
 
     # TODO: Use build_commands if available
 

--- a/ast/lib/build.py
+++ b/ast/lib/build.py
@@ -37,14 +37,14 @@ def build_structs(filename: str, build_commands: Optional[str] = None) -> List[S
     for dir in get_cmake_include_dirs():
         parse_args.append("-I")
         parse_args.append(dir)
-    else:
-        # Append default dirs
-        # - Append dir of file
-        file_dir = os.path.dirname(os.path.realpath(filename))
-        parse_args.append(f"-I{file_dir}")
-        # - Append project include dir
-        file_subdir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(filename)), "../.."))
-        parse_args.append(f"-I{file_subdir}")
+
+    # Append default dirs
+    # - Append dir of file
+    file_dir = os.path.dirname(os.path.realpath(filename))
+    parse_args.append(f"-I{file_dir}")
+    # - Append project include dir
+    file_subdir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(filename)), "../.."))
+    parse_args.append(f"-I{file_subdir}")
 
     # TODO: Use build_commands if available
 

--- a/ast/lib/helpers.py
+++ b/ast/lib/helpers.py
@@ -52,6 +52,28 @@ def temporary_file() -> Generator[Tuple[TextIOWrapper, str], None, None]:
     log.debug(f"Closed file {path}")
 
 
+def get_cmake_include_dirs() -> List[str]:
+    cmd = ["cmake", "--build", "build", "-t", "_ast_includes"]
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+
+    stdout, _ = proc.communicate(input=None, timeout=10)
+
+    dirs = []
+    for line in stdout.decode().splitlines():
+        if not line.startswith("@@INCLUDE_DIRS="):
+            continue
+        dirs += line.strip("@@INCLUDE_DIRS=").split(";")
+
+    log.debug(f"Include directories from cmake: {dirs}")
+    return dirs
+
+
 def get_clang_builtin_include_dirs() -> Tuple[List[str], List[str]]:
     quote_includes: List[str] = []
     angle_includes: List[str] = []

--- a/ast/lib/helpers.py
+++ b/ast/lib/helpers.py
@@ -55,12 +55,15 @@ def temporary_file() -> Generator[Tuple[TextIOWrapper, str], None, None]:
 def get_cmake_include_dirs() -> List[str]:
     cmd = ["cmake", "--build", "build", "-t", "_ast_includes"]
 
-    proc = subprocess.Popen(
-        cmd,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except:
+        return []
 
     stdout, _ = proc.communicate(input=None, timeout=10)
 

--- a/ast/lib/walker.py
+++ b/ast/lib/walker.py
@@ -63,12 +63,10 @@ class Walker:
         return False
 
     def walk(self, node: clang.cindex.Cursor) -> None:
-        node_in_file = bool(node.location.file and os.path.realpath(node.location.file.name) == self.real_filepath)
+        if node.location.file and not clang.cindex.Config().lib.clang_Location_isFromMainFile(node.location):
+            return
 
-        handled = False
-
-        if node_in_file:
-            handled = self.handle_node(node, None)
+        handled = self.handle_node(node, None)
 
         if not handled:
             for child in node.get_children():

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,13 @@ target_link_libraries(${PROJECT_NAME}
 # See https://github.com/boostorg/beast/issues/2661
 target_compile_definitions(${PROJECT_NAME} PRIVATE BOOST_ASIO_DISABLE_CONCEPTS)
 
+# Hack to get the include directories from Python
+get_target_property(_inc_dirs ${PROJECT_NAME} INCLUDE_DIRECTORIES)
+list(APPEND _inc_dirs ${Boost_INCLUDE_DIRS})
+list(APPEND _inc_dirs ${OPENSSL_INCLUDE_DIR})
+list(JOIN _inc_dirs ";" _inc_dir)
+add_custom_target(_ast_includes echo "@@INCLUDE_DIRS=${_inc_dir}")
+
 if (MSVC)
     # Add bigobj
     target_compile_options(${PROJECT_NAME} PRIVATE /EHsc /bigobj)


### PR DESCRIPTION
* Gets include directories from CMake (for boost)
* Uses clang to skip nodes - previously we'd walk through the whole STL and probably some system headers (that took ages)
* Handle both path separators